### PR TITLE
Add Enlightn to the list

### DIFF
--- a/data/tags.yml
+++ b/data/tags.yml
@@ -226,6 +226,9 @@
 - name: JSON
   tag: json
   type: other
+- name: Laravel
+  tag: laravel
+  type: other
 - name: LaTeX
   tag: latex
   type: other

--- a/data/tools/enlightn.yml
+++ b/data/tools/enlightn.yml
@@ -1,0 +1,16 @@
+name: Enlightn
+categories:
+  - linter
+tags:
+  - php
+  - security
+  - laravel
+license: LGPL-3.0 License
+types:
+  - cli
+source: 'https://github.com/enlightn/enlightn'
+homepage: 'https://www.laravel-enlightn.com/'
+description: >-
+  A static and dynamic analysis tool for Laravel applications that provides
+  recommendations to improve the performance, security and code reliability
+  of Laravel apps. Contains 120 automated checks.


### PR DESCRIPTION
We just launched [Enlightn](https://github.com/enlightn/enlightn), a static and dynamic analysis tool for Laravel apps that helps improve performance, security and code reliability. We launched it 2 days ago, currently has 124 ⭐. Hope you'll consider it!

[EDIT] If a single project can only go to one of the static analysis and dynamic analysis lists, I'd say it's a better fit for static analysis. In that case, you can close this PR and merge the one on the static analysis repo. Thanks!