### PR TITLE
Add Sydr

### DIFF
--- a/data/tools/casr.yml
+++ b/data/tools/casr.yml
@@ -1,0 +1,16 @@
+name: CASR
+categories:
+  - linter
+tags:
+  - security
+  - c
+  - cpp
+  - rust
+  - swift
+  - go
+license: Apache-2.0 License
+types:
+  - cli
+source: 'https://github.com/ispras/casr'
+homepage: 'https://crates.io/crates/casr'
+description: Crash Analysis and Severity Report.

--- a/data/tools/sydr.yml
+++ b/data/tools/sydr.yml
@@ -13,4 +13,7 @@ license: proprietary
 types:
   - cli
 homepage: 'https://sydr-fuzz.github.io/'
+resources:
+  - title: Sydr - Cutting Dynamic Symbolic Execution
+    url: https://www.ispras.ru/conf/2020/video/compiler-technology-11-december.mp4#t=6021
 description: Continuous Hybrid Fuzzing and Dynamic Analysis for Security Development Lifecycle.

--- a/data/tools/sydr.yml
+++ b/data/tools/sydr.yml
@@ -1,0 +1,16 @@
+name: Sydr
+categories:
+  - fuzzer
+  - linter
+tags:
+  - security
+  - c
+  - cpp
+  - rust
+  - swift
+  - go
+license: proprietary
+types:
+  - cli
+homepage: 'https://sydr-fuzz.github.io/'
+description: Continuous Hybrid Fuzzing and Dynamic Analysis for Security Development Lifecycle.


### PR DESCRIPTION
This PR adds a proprietary hybrid fuzzer Sydr that combines symbolic execution with modern fuzzers (libFuzzer and AFL++). Sydr is also a dynamic analysis tool that enables bug detection via dynamic symbolic execution. The list of found trophies is located [here](https://github.com/ispras/oss-sydr-fuzz/blob/master/TROPHIES.md).

Moreover, I added Casr that is an open source crash triage and severity estimation tool that is used inside Sydr.