### PR TITLE
Modernize Rust codebase: Fix chrono deprecations and enhance development tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,38 @@
-.PHONY: render
+# Dynamic Analysis Tools Repository Makefile
+
+.PHONY: render render-skip-deprecated check clippy fmt test clean help
+
+# Default target shows help
+help:
+	@echo "Available targets:"
+	@echo "  render              - Render README.md and JSON API from YAML sources"
+	@echo "  render-skip-deprecated - Render without deprecated tools"
+	@echo "  check               - Run cargo check"
+	@echo "  clippy              - Run clippy lints"
+	@echo "  fmt                 - Format Rust code"
+	@echo "  test                - Run tests"
+	@echo "  clean               - Clean build artifacts"
+	@echo "  help                - Show this help"
+
+# Main rendering targets
 render:
 	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --md-out README.md --json-out data/api
 
-.PHONY: render-skip-deprecated
 render-skip-deprecated:
 	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --md-out README.md --json-out data/api --skip-deprecated
+
+# Development targets
+check:
+	cargo check --manifest-path data/render/Cargo.toml
+
+clippy:
+	cargo clippy --manifest-path data/render/Cargo.toml -- -D warnings
+
+fmt:
+	cargo fmt --manifest-path data/render/Cargo.toml
+
+test:
+	cargo test --manifest-path data/render/Cargo.toml
+
+clean:
+	cargo clean --manifest-path data/render/Cargo.toml

--- a/data/render/clippy.toml
+++ b/data/render/clippy.toml
@@ -1,0 +1,14 @@
+# Clippy configuration for stricter linting
+# https://rust-lang.github.io/rust-clippy/master/index.html
+
+# Set the threshold for too many arguments
+too-many-arguments-threshold = 4
+
+# Set the threshold for too many lines
+too-many-lines-threshold = 100
+
+# Set the threshold for type complexity
+type-complexity-threshold = 250
+
+# Avoid suggesting wildcard imports
+avoid-breaking-exported-api = false

--- a/data/render/src/lib.rs
+++ b/data/render/src/lib.rs
@@ -51,8 +51,8 @@ pub async fn check_deprecated(token: String, entries: &mut Vec<Entry>) -> Result
         if let Ok(commit_list) = github.repo(owner, repo).commits().list("").await {
             let date = &commit_list[0].commit.author.date;
             let last_commit = NaiveDateTime::parse_from_str(date, "%Y-%m-%dT%H:%M:%SZ")?;
-            let last_commit_utc = DateTime::<Utc>::from_utc(last_commit, Utc);
-            let duration = Local::today().signed_duration_since(last_commit_utc.date());
+            let last_commit_utc: DateTime<Utc> = DateTime::from_naive_utc_and_offset(last_commit, Utc);
+            let duration = Local::now().date_naive().signed_duration_since(last_commit_utc.date_naive());
 
             if duration.num_days() > 365 {
                 entry.deprecated = Some(true);


### PR DESCRIPTION
- Fix chrono deprecation warnings by updating to modern APIs
- Add clippy configuration for stricter linting
- Update Makefile with development targets (check, clippy, fmt, test, clean, help)
- The Cargo.toml already had Rust 2024 edition and modern clippy lints configured

The goal here is to keep the codebase in sync with https://github.com/analysis-tools-dev/static-analysis/pull/1694.