### PR TITLE
Add cloud-audit - AWS security scanner

### DIFF
--- a/data/tools/cloud-audit.yml
+++ b/data/tools/cloud-audit.yml
@@ -1,0 +1,16 @@
+name: cloud-audit
+categories:
+  - linter
+tags:
+  - cloud
+license: MIT
+types:
+  - cli
+source: 'https://github.com/gebalamariusz/cloud-audit'
+homepage: 'https://haitmg.pl'
+description: >-
+  Fast, opinionated AWS security scanner with 47 curated checks.
+  Each finding includes copy-paste remediation in both AWS CLI and Terraform.
+  Features attack chain detection that correlates individual findings into
+  multi-step exploitable attack paths, and a built-in diff command
+  for tracking security posture changes between scans.


### PR DESCRIPTION
Adds [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Cloud category.

cloud-audit is an open-source AWS security scanner (MIT license) with:
- 47 curated checks (IAM, S3, EC2, RDS, VPC, Lambda, KMS, Secrets Manager)
- Copy-paste remediation in both AWS CLI and Terraform for every finding
- Attack chain detection (16 rules correlating findings into exploitable paths)
- Built-in diff command for CI/CD pipeline gating
- SARIF output for GitHub Code Scanning
- ~12 second scan time for a full AWS account

Similar to Prowler (already listed) but with an opinionated, low-noise approach and Terraform remediation output.