### PR TITLE
Add Dark-Moon (open source autonomous AI DAST)

### DIFF
--- a/data/tools/dark-moon.yml
+++ b/data/tools/dark-moon.yml
@@ -1,0 +1,18 @@
+name: Dark-Moon
+categories:
+  - dast
+tags:
+  - security
+  - api
+  - kubernetes
+  - web
+license: GPL-3.0
+types:
+  - cli
+  - service
+source: "https://github.com/ASCIT31/Dark-Moon"
+homepage: "https://dark-moon.org"
+description: >-
+  Open source autonomous AI penetration testing for web, Active Directory,
+  Kubernetes and API, with proof of exploitation on every finding and a local
+  Privacy Gateway so the model never sees real IPs, hosts or credentials.


### PR DESCRIPTION
Adds Dark-Moon, an open source (GPL-3.0) autonomous AI penetration testing tool for web, Active Directory, Kubernetes and API, with proof of exploitation on every finding and a local Privacy Gateway so the model never sees real IPs, hosts or credentials. Repo https://github.com/ASCIT31/Dark-Moon , site https://dark-moon.org