### PR TITLE
Add Offensive360 (proprietary DAST/application security platform)

### DIFF
--- a/data/tools/offensive360.yml
+++ b/data/tools/offensive360.yml
@@ -1,0 +1,50 @@
+name: Offensive360
+categories:
+- linter
+tags:
+- apex
+- c
+- ci
+- cobol
+- cpp
+- csharp
+- dart
+- elixir
+- go
+- groovy
+- java
+- javascript
+- kotlin
+- lua
+- objectivec
+- perl
+- php
+- python
+- r
+- ruby
+- rust
+- scala
+- security
+- swift
+- typescript
+- vbnet
+license: proprietary
+types:
+- service
+homepage: https://offensive360.com
+pricing: https://offensive360.com/pricing/
+plans:
+  free: false
+  oss: false
+description: Offensive360 is an application security platform whose DAST engine crawls and tests
+  running web applications and APIs (authenticated scanning, session handling, LLM-app testing)
+  alongside SAST, SCA, mobile app scanning and malware/binary analysis. Findings map to OWASP
+  Top 10 with remediation guidance. Deploys as SaaS or a self-hosted virtual appliance for offline/air-gapped
+  networks. SARIF output; CI/CD and IDE integrations.
+resources:
+- title: Product documentation and knowledge base
+  url: https://offensive360.com/knowledge-base/
+reviews:
+- https://www.gartner.com/reviews/market/application-security-testing/vendor/offensive-360/product/offensive-360
+- https://www.g2.com/products/offensive360/reviews
+- https://www.peerspot.com/products/offensive-360-reviews


### PR DESCRIPTION
Vendor disclosure: I represent O360 B.V., the company behind Offensive360.

Adding `data/tools/offensive360.yml` per the org's CONTRIBUTING conventions (mirrors my sibling PR analysis-tools-dev/static-analysis#1861):
- `license: proprietary`
- DAST-focused factual description, <500 chars
- Tags validated against this repo's `data/tags.yml`
- Impact bar: reviewed on Gartner Peer Insights (4.6/5), G2, PeerSpot (links in `reviews`); product since 2020

Happy to adjust format if preferred.